### PR TITLE
MaxMind requires HTTPS for database downloads

### DIFF
--- a/geodata_download.sh
+++ b/geodata_download.sh
@@ -6,10 +6,10 @@
 # https://gixtools.net
 #
 mkdir geodata && cd geodata
-wget http://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum2.zip
-wget http://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum2v6.zip
-wget http://geolite.maxmind.com/download/geoip/database/GeoIPCountryCSV.zip
-wget http://geolite.maxmind.com/download/geoip/database/GeoIPv6.csv.gz
+wget https://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum2.zip
+wget https://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum2v6.zip
+wget https://geolite.maxmind.com/download/geoip/database/GeoIPCountryCSV.zip
+wget https://geolite.maxmind.com/download/geoip/database/GeoIPv6.csv.gz
 
 unzip GeoIPASNum2.zip
 unzip GeoIPASNum2v6.zip


### PR DESCRIPTION
MaxMind will be requiring HTTPS for all database download requests starting in March 2024.

See [this release note](https://dev.maxmind.com/geoip/release-notes/2023#api-policies---temporary-enforcement-on-october-17-2023).